### PR TITLE
first version of bashc

### DIFF
--- a/package/deb/create.sh
+++ b/package/deb/create.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+#
+# bashkeleton - Skeleton for Bash applications
+# https://github.com/dealfonso/bashkeleton
+#
+# Copyright (C) caralla@upv.es
+# Developed by Carlos A. caralla@upv.es
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+SRCFOLDER=$1
+if [ "$SRCFOLDER" == "" ]; then
+  SRCFOLDER="."
+fi
+
+source "$SRCFOLDER/appname"
+if [ $? -ne 0 -o "$APPNAME" == "" ]; then
+  echo "could not find the name of the application"
+  exit 1
+fi
+
+source "$SRCFOLDER/version"
+if [ $? -ne 0 -o "$VERSION" == "" ]; then
+  echo "could not find the version for the package"
+  exit 1
+fi
+
+REVISION=${VERSION##*-}
+VERSION=${VERSION%%-*}
+
+FNAME=build/${APPNAME}_${VERSION}-${REVISION}
+mkdir -p "${FNAME}/DEBIAN"
+
+${SRCFOLDER}/INSTALL.sh "${SRCFOLDER}" "${FNAME}"
+
+cat > "${FNAME}/DEBIAN/control" << EOF
+Package: ${APPNAME}
+Version: ${VERSION}-${REVISION}
+Section: base
+Priority: optional
+Architecture: all
+Depends: bash, libc-bin, coreutils
+Maintainer: Carlos A. <caralla@upv.es>
+Description: ${APPNAME}
+ skeleton of a bash application
+EOF
+
+cat > "${FNAME}/DEBIAN/preinst" <<\EOF
+#!/bin/sh
+EOF
+
+cat > "${FNAME}/DEBIAN/postinst" <<\EOF
+#!/bin/sh
+EOF
+
+cat > "${FNAME}/DEBIAN/postrm" <<\EOF
+#!/bin/sh
+EOF
+
+cat > "${FNAME}/DEBIAN/prerm" <<\EOF
+#!/bin/sh
+EOF
+
+chmod +x "${FNAME}/DEBIAN/postinst"
+chmod +x "${FNAME}/DEBIAN/postrm"
+chmod +x "${FNAME}/DEBIAN/preinst"
+chmod +x "${FNAME}/DEBIAN/prerm"
+
+cd $FNAME/etc > /dev/null 2> /dev/null
+[ $? -eq 0 ] && CONFFILES="$(find * -type f -printf '/etc/%p\n')" && cd -
+
+if [ "$CONFFILES" != "" ]; then
+  echo "$CONFFILES" > "${FNAME}/DEBIAN/conffiles"
+fi
+
+cd "${FNAME}"
+find . -type f ! -regex '.*.hg.*' ! -regex '.*?debian-binary.*' ! -regex '.*?DEBIAN.*' -printf "%P " | xargs md5sum > "DEBIAN/md5sums"
+cd -
+
+fakeroot dpkg-deb --build "${FNAME}"
+
+mv ${FNAME}.deb .

--- a/package/rpm/create.sh
+++ b/package/rpm/create.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+#
+# DoSH - Docker SHell
+# https://github.com/grycap/dosh
+#
+# Copyright (C) GRyCAP - I3M - UPV 
+# Developed by Carlos A. caralla@upv.es
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+SRCFOLDER=$1
+if [ "$SRCFOLDER" == "" ]; then
+  SRCFOLDER="."
+fi
+
+source "$SRCFOLDER/appname"
+if [ $? -ne 0 -o "$APPNAME" == "" ]; then
+  echo "could not find the name of the application"
+  exit 1
+fi
+
+source "$SRCFOLDER/version"
+if [ $? -ne 0 -o "$VERSION" == "" ]; then
+  echo "could not find the version for the package"
+  exit 1
+fi
+
+MANFOLDER="$SRCFOLDER/doc/man"
+if [ ! -d "$MANFOLDER" ]; then
+  MANFOLDER=
+fi
+
+REVISION=${VERSION##*-}
+VERSION=${VERSION%%-*}
+
+FNAME=build/${APPNAME}-${VERSION}
+rm -rf "$FNAME"
+
+${SRCFOLDER}/INSTALL.sh "${SRCFOLDER}" "${FNAME}"
+
+tar czf ${APPNAME}-${VERSION}.tar.gz -C build ${APPNAME}-${VERSION}
+TARFILES="$(tar tf ${APPNAME}-${VERSION}.tar.gz | sed "s/${APPNAME}-${VERSION}//g" | sed '/\/$/d')"
+
+cat > ${APPNAME}.spec <<EOF
+%define version $VERSION
+%define revision $REVISION
+Summary:        bashkeleton - skeleton of a bash application
+License:        Apache 2.0
+Name:           ${APPNAME}
+EOF
+
+cat >> ${APPNAME}.spec <<\EOF
+Version:        %{version}
+Release:        %{revision}
+Group:          System Environment
+URL:            https://github.com/dealfonso/bashkeleton
+Packager:       Carlos A. <caralla@upv.es>
+Requires:       bash, tar, coreutils, glibc-common
+Source0:        %{name}-%{version}.tar.gz
+BuildArch:      noarch
+
+%description 
+ skeleton of a bash application 
+
+%prep
+%setup -q
+%build
+
+%install
+mkdir -p $RPM_BUILD_ROOT
+cp -r * $RPM_BUILD_ROOT
+
+%clean
+rm -rf $RPM_BUILD_ROOT
+
+%post
+
+%postun
+
+EOF
+cat >> ${APPNAME}.spec <<EOF
+%files
+%defattr(-,root,root,755)
+$(echo "$TARFILES" | grep -v '^/etc' | grep '/bin/')
+%defattr(-,root,root,644)
+$(echo "$TARFILES" | grep -v '^/etc' | grep -v '/bin/')
+EOF
+
+if [ "$(ls $FNAME/etc)" != "" ]; then
+cat >> ${APPNAME}.spec <<EOF
+%config
+$(echo "$TARFILES" | grep '^/etc' | grep -v '/bin/')
+EOF
+fi
+
+cp ${APPNAME}-${VERSION}.tar.gz ~/rpmbuild/SOURCES/
+rpmbuild -ba ${APPNAME}.spec
+cp ~/rpmbuild/RPMS/noarch/${APPNAME}-${VERSION}-${REVISION}.noarch.rpm .

--- a/src/bashc
+++ b/src/bashc
@@ -1,0 +1,289 @@
+#!/bin/bash
+function usage() {
+  cat <<EOF
+
+This is a tool that tries to flatten bash applications. It is useful if you use source statements
+  to organize your files. In this case, this tool will make a single file with no outern dependencies.
+
+  The application also includes one tool to try to remove unused functions (strip-functions). This
+  is useful to create libraries with a lot of funcions in it, but only include those that are used in
+  the resulting application.
+
+$0 <options>
+  --execute|-e              Execute the resulting file (it admits parameters at the end)
+  --chdir|-c <folder>       Changes the working directory to the one provided as a parameter
+                            (i.e. cd <folder> ... cd -)
+  --chdir-to-file|-C        Changes the working directory to the one in which the file is
+                            (in case that the file is in other folder)
+  --file|-f <filename>      Outputs the resulting process to the file <filename>
+  --skipmissing|-s          Skips the files that could not be found when detecting the command
+                            source. Otherwise the app will stop if cannot find the file to include
+  --onlyonce|-o             The app will try to detect the "source" statements only once. Take
+                            into account that if one sourced file also includes a "source" statement,
+                            using this mode it will not be sourced.
+  --strip-functions|-S      Try to remove the unused functions (useful to create minimal commands)
+  --verbose | -v            Shows more information about the procedure.
+  --debug                   Shows a lot more information about the procedure.
+  --help | -h               Shows this help and exits.
+  
+EOF
+}
+
+# Some basic includes
+source lib/debug.bash
+source lib/temp.bash
+source lib/utils.bash
+source lib/config.bash
+source lib/parameters.bash
+source version
+
+# Parse the commandline into an array
+bashc.parameter_parse_commandline "$@"
+
+function getfunctions_fnc() {
+echo "$1" | awk '
+  /^[ \t]*function (.*)/{
+    match($0, /^[ \t]*function ([^{(]+).*{.*/, arr)
+    fncname=arr[1]
+    print fncname
+  }
+' 
+}
+
+function strip_fnc() {
+# https://stackoverflow.com/a/33516495
+RESTOFCODE='
+  infunction {
+    analized_str=$0;
+    
+    # if in double quote, remote anything up othe double quote
+    if (in_dquote==1)
+      if (sub(/^[^"\\]*(\\.[^"\\]*)*"/,"", analized_str)) in_dquote=0;
+
+    # if in single quote, remote anything up the single quote
+    if (in_squote==1)
+      if (sub(/^[^'"'"']*'"'"'/,"", analized_str)) in_squote=0;
+
+    # if still in double quote or single quote, skip
+    if (in_dquote || in_squote) next;
+
+    # Remove quoted sentences
+    while (sub(/"[^"\\]*(\\.[^"\\]*)*"|'"'"'[^'"'"']*'"'"'/,"",analized_str));
+
+    # Remove anything from the single quote (or the double quote)
+    if (index(analized_str, "\"")< index (analized_str, "'"'"'")) {
+      if (sub(/"[^"\\]*(\\.[^"\\]*)*$/,"", analized_str))
+        in_dquote=1;
+      else    
+        if (sub(/'"'"'[^'"'"']*$/,"", analized_str)) 
+          in_squote=1;
+    }  else {
+      if (sub(/'"'"'[^'"'"']*$/,"", analized_str))      
+        in_squote=1;
+      else    
+        if (sub(/"[^"\\]*(\\.[^"\\]*)*$/,"", analized_str))
+          in_dquote=1;
+    }
+
+    # Remove comments (beware of the {#arr[@]} bash expansion)
+    sub(/[^{]#.*$/,"",analized_str);
+
+    # If it is empty, skip
+    if (match(analized_str,/^[ \t]*$/)) next;
+
+    # Count number of { and } in line
+    b += split(analized_str, tmp, "{");
+    b -= split(analized_str, tmp, "}");
+
+    # If there are no more braces, we have finished
+    if (b<=0) infunction = 0;
+
+    # If we had more closing braces, it is a bug in the original file
+    next;
+  }
+'
+echo "$2" | awk "
+  /^[ \t]*function [ \t]*$1[ \t\({].*/{
+    infunction=1;
+    b=0; # The factor between open / close brackets
+    in_squote=0;
+    in_dquote=0;
+  }
+  /^[ \t]*$/{ # Remove empty lines
+    next;
+  }
+  $RESTOFCODE
+  1 # Print line"
+}
+
+TMPDIR=
+OUTFILE=
+FILETOJOIN=
+WORKINGFOLDER=.
+PARAMS=()
+n=0
+
+DEBUG=
+EXECUTE=true
+ONLYONCE=false
+SKIPMISSING=false
+STRIPFUNCTIONS=false
+
+bashc.parameters_start
+while bashc.parameters_next; do
+  PARAM="$(bashc.parameter_current)"
+  case "$PARAM" in
+    --folder|-f)            bashc.parameters_next
+                            WORKINGFOLDER="$(bashc.parameter_current)";;
+    --chdir-to-file-folder|-C)     
+                            CHDIRTOFILE=true;;
+    --output|-o)            bashc.parameters_next
+                            OUTFILE="$(bashc.parameter_current)";;
+    --compile|-c)           EXECUTE=false;;
+    --skipmissing|-s)       SKIPMISSING=true;;
+    --include-once|-O)      ONLYONCE=true;;
+    --verbose|-v)           VERBOSE=true;;
+    --debug)                DEBUG=true;;
+    --help | -h)            usage && bashc.finalize;;
+    --strip-functions | -S) STRIPFUNCTIONS=true;;
+    --|*)                   [ "$PARAM" == "--" ] && bashc.parameters_next
+                            while ! bashc.parameters_end; do
+                              PARAM="$(bashc.parameter_current)"
+                              if [ "$FILETOJOIN" == "" ]; then
+                                FILETOJOIN="$PARAM"
+                              else
+                                PARAMS+=("$PARAM")       
+                              fi                      
+                              bashc.parameters_next     
+                            done;;
+  esac
+  n=$(($n+1))
+done
+
+if [ "$FILETOJOIN" == "" ]; then
+  bashc.finalize 0 "no input file provided"
+fi
+
+if [ "$OUTFILE" == "-" ]; then
+  OUTFILE=""
+fi
+
+# Change to the working folder (get it from the file, if flag -C is set)
+if [ "$CHDIRTOFILE" == "true" ]; then
+  WORKINGFOLDER="$(dirname "$FILETOJOIN")"
+  FILETOJOIN="$(basename "$FILETOJOIN")"
+fi
+
+cd "$WORKINGFOLDER" || bashc.finalize 1 "not valid working folder $WORKINGFOLDER"
+
+# Prepare
+_FILES_INCLUDED=()
+_TMPFILE1="$(bashc.tempfile)"
+cp "$FILETOJOIN" "$_TMPFILE1"
+HAVEWORK=true
+
+# Will have work while some "source" statements are detected
+while [ "$HAVEWORK" == "true" ]; do
+  _NXT_SRC="$(cat "$_TMPFILE1" | sed 's/#.*//g' | sed 's/^[ \t]*//g' | sed 's/[ \t]*$//g' | sed '/^$/d' | grep '^source ' | head -n 1)"
+  if [ "$_NXT_SRC" != "" ]; then
+    _TMPFILE2=$(bashc.tempfile)
+    _SRC_FILE="$(bashc.trim "${_NXT_SRC:7}")"
+
+    if [ -e "$_SRC_FILE" ]; then
+      SOLVEINCLUDE=true
+      FILEINCLUDED="$(echo "${_FILES_INCLUDED[@]}" | grep "$_SRC_FILE")"
+      if [ "$FILEINCLUDED" != "" ]; then
+        if [ "$ONLYONCE" == "true" ]; then
+          p_warning "file $_SRC_FILE has already been included"
+          SOLVEINCLUDE=false
+        fi
+      fi
+      if [ "$SOLVEINCLUDE" == "true" ]; then
+        p_debug "including file $_SRC_FILE"
+        _CONTROLFIELD="$(cat /proc/sys/kernel/random/uuid)"
+        sed -e "0,/^$(bashc.sanitize "$_NXT_SRC")\$/s//$_CONTROLFIELD/"  -e "/$_CONTROLFIELD/ {
+        r $_SRC_FILE
+        a
+        d
+        }" "$_TMPFILE1" > "$_TMPFILE2" 
+        _FILES_INCLUDED+=("$_SRC_FILE")
+      else
+        p_debug "skipping file $_SRC_FILE"
+        cat "$_TMPFILE1" | sed "s/^\\($(bashc.sanitize "$_NXT_SRC")\\)\$/# Already included: \\1/" > "$_TMPFILE2"
+      fi
+    else
+      p_warning "could not find file $_SRC_FILE"
+      if [ "$SKIPMISSING" == "true" ]; then
+        cat "$_TMPFILE1" | sed "s/^\\($(bashc.sanitize "$_NXT_SRC")\\)\$/# Missing file: \\1/" > "$_TMPFILE2"
+      else
+        bashc.finalize 1 "could not find file $_SRC_FILE"
+      fi
+    fi
+    mv "$_TMPFILE2" "$_TMPFILE1"
+  else
+    HAVEWORK=false
+  fi
+done
+
+function remove_unused_functions() {
+  local REMOVED CURRENT_CONTENT STRIPPED_CONTENT FOUND_CONTENT
+  local FUNCTIONS="$(getfunctions_fnc "$F_CONTENT" | tr '\n' ' ')"
+  p_debug "functions: 
+  $FUNCTIONS"
+
+  CURRENT_CONTENT="$1"
+  local i=0
+  for f in $FUNCTIONS; do
+    STRIPPED_CONTENT="$(strip_fnc "$f" "$CURRENT_CONTENT")"
+    FOUND_CONTENT="$(echo "$STRIPPED_CONTENT" | grep "\b$f\b")"
+    if [ "$FOUND_CONTENT" == "" ]; then
+      p_debug "removing function '$f'"
+      CURRENT_CONTENT="$STRIPPED_CONTENT"
+      REMOVED=true
+    else
+      p_debug "keeping function '$f'"
+    fi
+    #p_debug "$i -----------------------------------------------------------"
+    #p_debug "$CURRENT_CONTENT"
+    #p_debug "$i ==========================================================="
+    i=$((i+1))
+  done
+  echo "$CURRENT_CONTENT"
+  if [ "$REMOVED" == "true" ]; then
+    return 1
+  fi
+  return 0
+}
+
+# Now let's strip the functions
+if [ "$STRIPFUNCTIONS" == "true" ]; then
+  p_debug "$_TMPFILE1"
+  F_CONTENT="$(cat "$_TMPFILE1")"
+  REPEAT=true
+
+  while [ "$REPEAT" == "true" ]; do
+    F_CONTENT="$(remove_unused_functions "$F_CONTENT")"
+    if [ $? -eq 0 ]; then
+      REPEAT=false
+      p_debug "no more changes"
+    fi
+  done
+
+  echo "$F_CONTENT" > "$_TMPFILE1"
+fi
+
+if [ "$OUTFILE" != "" ]; then
+  mv "$_TMPFILE1" "$OUTFILE"
+else
+  if [ "$EXECUTE" == "true" ]; then
+    OUTFILE="$_TMPFILE1"
+  else
+    cat "$_TMPFILE1"  
+  fi
+fi
+
+if [ "$EXECUTE" == "true" ]; then
+  bash -- "$OUTFILE" "${PARAMS[@]}"
+fi
+
+cd - > /dev/null

--- a/src/bashc
+++ b/src/bashc
@@ -4,24 +4,36 @@ function usage() {
 
 This is a tool that tries to flatten bash applications. It is useful if you use source statements
   to organize your files. In this case, this tool will make a single file with no outern dependencies.
+  The sourced files are searched in the folders that are included in the BASHC_LIB_PATH configuration
+  variable. It is expressed in a PATH-like syntax. The value for BASHC_LIB_PATH is obtained from the 
+  env variables and later from the configuration files. The default value is '.'
 
   The application also includes one tool to try to remove unused functions (strip-functions). This
   is useful to create libraries with a lot of funcions in it, but only include those that are used in
   the resulting application.
 
-$0 <options>
-  --execute|-e              Execute the resulting file (it admits parameters at the end)
-  --chdir|-c <folder>       Changes the working directory to the one provided as a parameter
+$0 <options> <script> -- <parameters>
+  <script>                  Script to build.
+  <parameters>              Parameters to pass to the resulting script (if has to be executed)
+  --execute|-e              Execute the resulting file (it admits parameters at the end). This is the
+                            default option.
+  --compile|-c              Compiles the script and outputs to the file (or the stdout if not provided
+                            any output file).                           
+  --output|-o <file>        File in which the resulting compilation (i.e. output of -c) will be left. If
+                            not stated any file, will output to the stdout (i.e. -)
+  --chdir|-C <folder>       Changes the working directory to the one provided as a parameter
                             (i.e. cd <folder> ... cd -)
+  --include|-I <path>       Use the following path-like expressions to find the files that are sourced
+                            in the code. That path will be included at the end of the BASHC_LIB_PATH path.
   --chdir-to-file|-C        Changes the working directory to the one in which the file is
                             (in case that the file is in other folder)
-  --file|-f <filename>      Outputs the resulting process to the file <filename>
   --skipmissing|-s          Skips the files that could not be found when detecting the command
                             source. Otherwise the app will stop if cannot find the file to include
-  --onlyonce|-o             The app will try to detect the "source" statements only once. Take
+  --include-once|-O         The app will try to detect the "source" statements only once. Take
                             into account that if one sourced file also includes a "source" statement,
                             using this mode it will not be sourced.
   --strip-functions|-S      Try to remove the unused functions (useful to create minimal commands)
+  --version | -V            Outputs the version number and finalizes.
   --verbose | -v            Shows more information about the procedure.
   --debug                   Shows a lot more information about the procedure.
   --help | -h               Shows this help and exits.
@@ -41,79 +53,117 @@ source version
 bashc.parameter_parse_commandline "$@"
 
 function getfunctions_fnc() {
-echo "$1" | awk '
-  /^[ \t]*function (.*)/{
-    match($0, /^[ \t]*function ([^{(]+).*{.*/, arr)
-    fncname=arr[1]
-    print fncname
-  }
-' 
+  echo "$1" | awk '
+    /^[ \t]*function (.*)/{
+      match($0, /^[ \t]*function ([^{(]+).*{.*/, arr)
+      fncname=arr[1]
+      print fncname
+    }
+  ' 
 }
 
 function strip_fnc() {
-# https://stackoverflow.com/a/33516495
-RESTOFCODE='
-  infunction {
-    analized_str=$0;
-    
-    # if in double quote, remote anything up othe double quote
-    if (in_dquote==1)
-      if (sub(/^[^"\\]*(\\.[^"\\]*)*"/,"", analized_str)) in_dquote=0;
+  RESTOFCODE='
+    infunction {
+      analized_str=$0;
+      
+      # if in double quote, remote anything up othe double quote
+      if (in_dquote==1)
+        if (sub(/^[^"\\]*(\\.[^"\\]*)*"/,"", analized_str)) in_dquote=0;
 
-    # if in single quote, remote anything up the single quote
-    if (in_squote==1)
-      if (sub(/^[^'"'"']*'"'"'/,"", analized_str)) in_squote=0;
+      # if in single quote, remote anything up the single quote
+      if (in_squote==1)
+        if (sub(/^[^'"'"']*'"'"'/,"", analized_str)) in_squote=0;
 
-    # if still in double quote or single quote, skip
-    if (in_dquote || in_squote) next;
+      # if still in double quote or single quote, skip
+      if (in_dquote || in_squote) next;
 
-    # Remove quoted sentences
-    while (sub(/"[^"\\]*(\\.[^"\\]*)*"|'"'"'[^'"'"']*'"'"'/,"",analized_str));
+      # Remove quoted sentences
+      while (sub(/"[^"\\]*(\\.[^"\\]*)*"|'"'"'[^'"'"']*'"'"'/,"",analized_str));
 
-    # Remove anything from the single quote (or the double quote)
-    if (index(analized_str, "\"")< index (analized_str, "'"'"'")) {
-      if (sub(/"[^"\\]*(\\.[^"\\]*)*$/,"", analized_str))
-        in_dquote=1;
-      else    
+      i_comment=index(analized_str, "#");
+      i_squote=index(analized_str, "'"'"'");
+      i_dquote=index(analized_str, "\"");
+
+      if (i_comment == 0) i_comment=length(analized_str);
+      if (i_squote == 0) i_squote=length(analized_str);
+      if (i_dquote == 0) i_dquote=length(analized_str);
+
+      if (i_comment <= i_squote && i_comment <= i_dquote) {
+        # Remove comments (beware of the {#arr[@]} bash expansion)
+        sub(/[^{]#.*$/,"",analized_str);
+      }
+      if (i_squote <= i_dquote) {
         if (sub(/'"'"'[^'"'"']*$/,"", analized_str)) 
           in_squote=1;
-    }  else {
-      if (sub(/'"'"'[^'"'"']*$/,"", analized_str))      
-        in_squote=1;
-      else    
         if (sub(/"[^"\\]*(\\.[^"\\]*)*$/,"", analized_str))
           in_dquote=1;
+      } else {
+        if (sub(/"[^"\\]*(\\.[^"\\]*)*$/,"", analized_str))
+          in_dquote=1;
+        if (sub(/'"'"'[^'"'"']*$/,"", analized_str)) 
+          in_squote=1;
+      }
+
+      # If it is empty, skip
+      if (match(analized_str,/^[ \t]*$/)) next;
+
+      # Count number of { and } in line
+      b += split(analized_str, tmp, "{");
+      b -= split(analized_str, tmp, "}");
+
+      # If there are no more braces, we have finished
+      if (b<=0) infunction = 0;
+
+      # If we had more closing braces, it is a bug in the original file
+      next;
     }
+  '
+  local FNC_NAME="${1//\./\\\.}"
 
-    # Remove comments (beware of the {#arr[@]} bash expansion)
-    sub(/[^{]#.*$/,"",analized_str);
+  echo "$2" | awk "
+    /^[ \t]*function [ \t]*$FNC_NAME[ \t\({].*/{
+      infunction=1;
+      b=0; # The factor between open / close brackets
+      in_squote=0;
+      in_dquote=0;
+    }
+    /^[ \t]*$/{ # Remove empty lines
+      next;
+    }
+    $RESTOFCODE
+    1 # Print line"
+}
 
-    # If it is empty, skip
-    if (match(analized_str,/^[ \t]*$/)) next;
+function remove_unused_functions() {
+  local REMOVED CURRENT_CONTENT STRIPPED_CONTENT FOUND_CONTENT
+  CURRENT_CONTENT="$1"
+  local FUNCTIONS="$(getfunctions_fnc "$CURRENT_CONTENT" | tr '\n' ' ')"
+  p_debug "functions: 
+  $FUNCTIONS"
 
-    # Count number of { and } in line
-    b += split(analized_str, tmp, "{");
-    b -= split(analized_str, tmp, "}");
-
-    # If there are no more braces, we have finished
-    if (b<=0) infunction = 0;
-
-    # If we had more closing braces, it is a bug in the original file
-    next;
-  }
-'
-echo "$2" | awk "
-  /^[ \t]*function [ \t]*$1[ \t\({].*/{
-    infunction=1;
-    b=0; # The factor between open / close brackets
-    in_squote=0;
-    in_dquote=0;
-  }
-  /^[ \t]*$/{ # Remove empty lines
-    next;
-  }
-  $RESTOFCODE
-  1 # Print line"
+  local i=0
+  for f in $FUNCTIONS; do
+    STRIPPED_CONTENT="$(strip_fnc "$f" "$CURRENT_CONTENT")"
+    FOUND_CONTENT="$(echo "$STRIPPED_CONTENT" | grep "\b$f\b")"
+    if [ "$FOUND_CONTENT" == "" ]; then
+      p_debug "removing function '$f'"
+      CURRENT_CONTENT="$STRIPPED_CONTENT"
+      REMOVED=true
+    else
+      p_debug "keeping function '$f'"
+    fi
+    # p_debug "$i -----------------------------------------------------------"
+    # p_debug "$CURRENT_CONTENT"
+    # p_debug "$STRIPPED_CONTENT"
+    # p_debug "$i ==========================================================="
+    i=$((i+1))
+  done
+  echo "$CURRENT_CONTENT"
+  if [ "$REMOVED" == "true" ]; then
+    return 1
+  fi
+  return 0
 }
 
 TMPDIR=
@@ -122,23 +172,27 @@ FILETOJOIN=
 WORKINGFOLDER=.
 PARAMS=()
 n=0
-
 DEBUG=
 EXECUTE=true
 ONLYONCE=false
 SKIPMISSING=false
 STRIPFUNCTIONS=false
 
+# Prepare the default lib path (i.e. find files in the current folder)
+BASHC_LIB_PATH=${BASHC_LIB_PATH:-"."}
+
 bashc.parameters_start
 while bashc.parameters_next; do
-  PARAM="$(bashc.parameter_current)"
+  PARAM="$(bashc.parameters_current)"
   case "$PARAM" in
+    --include|-I)           bashc.parameters_next
+                            BASHC_LIB_PATH_ADD="$(bashc.parameters_current)";;
     --folder|-f)            bashc.parameters_next
-                            WORKINGFOLDER="$(bashc.parameter_current)";;
+                            WORKINGFOLDER="$(bashc.parameters_current)";;
     --chdir-to-file-folder|-C)     
                             CHDIRTOFILE=true;;
     --output|-o)            bashc.parameters_next
-                            OUTFILE="$(bashc.parameter_current)";;
+                            OUTFILE="$(bashc.parameters_current)";;
     --compile|-c)           EXECUTE=false;;
     --skipmissing|-s)       SKIPMISSING=true;;
     --include-once|-O)      ONLYONCE=true;;
@@ -146,9 +200,11 @@ while bashc.parameters_next; do
     --debug)                DEBUG=true;;
     --help | -h)            usage && bashc.finalize;;
     --strip-functions | -S) STRIPFUNCTIONS=true;;
+    --version|-V)           p_out "$VERSION"
+                            bashc.finalize 0;;
     --|*)                   [ "$PARAM" == "--" ] && bashc.parameters_next
                             while ! bashc.parameters_end; do
-                              PARAM="$(bashc.parameter_current)"
+                              PARAM="$(bashc.parameters_current)"
                               if [ "$FILETOJOIN" == "" ]; then
                                 FILETOJOIN="$PARAM"
                               else
@@ -159,6 +215,8 @@ while bashc.parameters_next; do
   esac
   n=$(($n+1))
 done
+
+CONFIGFILES="/etc/default/bashc.conf /etc/bashc/bashc.conf /etc/bashc.conf $HOME/.bashc etc/bashc.conf"
 
 if [ "$FILETOJOIN" == "" ]; then
   bashc.finalize 0 "no input file provided"
@@ -176,6 +234,35 @@ fi
 
 cd "$WORKINGFOLDER" || bashc.finalize 1 "not valid working folder $WORKINGFOLDER"
 
+# Read the config files
+for F in $CONFIGFILES; do
+  p_debug "processing file configuration file $F"
+  bashc.readconf "$F" BASHC_LIB_PATH
+  RESULT=$?
+  if [ $RESULT -eq 255 ]; then
+    p_debug "configuration file $F does not exist"
+  else
+    if [ $RESULT -gt 10 ]; then
+      bashc.finalize 1 "too errors in the configuration file ($RESULT)"
+    else
+      p_info "configuration read from file $F"
+    fi
+  fi
+done
+
+# Append the paths in the parameters
+if [ "$BASHC_LIB_PATH_ADD" != "" ]; then
+  BASHC_LIB_PATH="$BASHC_LIB_PATH:$BASHC_LIB_PATH_ADD"
+fi
+
+p_info "BASHC_LIB_PATH=$BASHC_LIB_PATH"
+
+# Prepare the lib path to be easier to use (add the folder . as a default)
+BASHC_LIB_PATH="$(echo -e "${BASHC_LIB_PATH//\:/\\n}")"
+# Q: Not sure if adding the current folder to the search path.
+# A: No. Just because how PATH variable works.
+# BASHC_LIB_PATH="$(echo -e ".\\n${BASHC_LIB_PATH//\:/\\n}")"
+
 # Prepare
 _FILES_INCLUDED=()
 _TMPFILE1="$(bashc.tempfile)"
@@ -189,7 +276,17 @@ while [ "$HAVEWORK" == "true" ]; do
     _TMPFILE2=$(bashc.tempfile)
     _SRC_FILE="$(bashc.trim "${_NXT_SRC:7}")"
 
-    if [ -e "$_SRC_FILE" ]; then
+    FOUND=false
+    for F in $BASHC_LIB_PATH; do
+      if [ "$F" != "" -a -e "$F/$_SRC_FILE" ]; then
+        p_info "found file $_SRC_FILE in folder $F"
+        _SRC_FILE="$F/$_SRC_FILE"
+        FOUND=true
+        break
+      fi
+    done
+
+    if [ "$FOUND" == "true" ]; then
       SOLVEINCLUDE=true
       FILEINCLUDED="$(echo "${_FILES_INCLUDED[@]}" | grep "$_SRC_FILE")"
       if [ "$FILEINCLUDED" != "" ]; then
@@ -212,7 +309,7 @@ while [ "$HAVEWORK" == "true" ]; do
         cat "$_TMPFILE1" | sed "s/^\\($(bashc.sanitize "$_NXT_SRC")\\)\$/# Already included: \\1/" > "$_TMPFILE2"
       fi
     else
-      p_warning "could not find file $_SRC_FILE"
+      p_warning "could not find file $_SRC_FILE. If it should be found, please adjust your BASHC_LIB_PATH variable in configuration"
       if [ "$SKIPMISSING" == "true" ]; then
         cat "$_TMPFILE1" | sed "s/^\\($(bashc.sanitize "$_NXT_SRC")\\)\$/# Missing file: \\1/" > "$_TMPFILE2"
       else
@@ -225,39 +322,9 @@ while [ "$HAVEWORK" == "true" ]; do
   fi
 done
 
-function remove_unused_functions() {
-  local REMOVED CURRENT_CONTENT STRIPPED_CONTENT FOUND_CONTENT
-  local FUNCTIONS="$(getfunctions_fnc "$F_CONTENT" | tr '\n' ' ')"
-  p_debug "functions: 
-  $FUNCTIONS"
-
-  CURRENT_CONTENT="$1"
-  local i=0
-  for f in $FUNCTIONS; do
-    STRIPPED_CONTENT="$(strip_fnc "$f" "$CURRENT_CONTENT")"
-    FOUND_CONTENT="$(echo "$STRIPPED_CONTENT" | grep "\b$f\b")"
-    if [ "$FOUND_CONTENT" == "" ]; then
-      p_debug "removing function '$f'"
-      CURRENT_CONTENT="$STRIPPED_CONTENT"
-      REMOVED=true
-    else
-      p_debug "keeping function '$f'"
-    fi
-    #p_debug "$i -----------------------------------------------------------"
-    #p_debug "$CURRENT_CONTENT"
-    #p_debug "$i ==========================================================="
-    i=$((i+1))
-  done
-  echo "$CURRENT_CONTENT"
-  if [ "$REMOVED" == "true" ]; then
-    return 1
-  fi
-  return 0
-}
-
 # Now let's strip the functions
 if [ "$STRIPFUNCTIONS" == "true" ]; then
-  p_debug "$_TMPFILE1"
+  p_info "stripping unused functions"
   F_CONTENT="$(cat "$_TMPFILE1")"
   REPEAT=true
 
@@ -278,12 +345,14 @@ else
   if [ "$EXECUTE" == "true" ]; then
     OUTFILE="$_TMPFILE1"
   else
-    cat "$_TMPFILE1"  
+    cat "$_TMPFILE1"
   fi
 fi
 
 if [ "$EXECUTE" == "true" ]; then
+  p_info "executing the resulting app with params ${PARAMS[@]}"
   bash -- "$OUTFILE" "${PARAMS[@]}"
 fi
 
+p_debug "returning to the previous folder"
 cd - > /dev/null

--- a/src/bashcbuild
+++ b/src/bashcbuild
@@ -1,0 +1,65 @@
+#!/bin/bash
+#
+# bashcbuild - builds a package
+# https://github.com/
+#
+# Copyright (C) GRyCAP - I3M - UPV 
+# Developed by Carlos A. caralla@upv.es
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+function usage() {
+  cat <<EOF
+
+this is a tool that runs ...
+
+$0 <options>
+
+  --version | -V            Shows the version number and finalizes.
+  --verbose | -v            Shows more information about the procedure.
+  --debug                   Shows a lot more information about the procedure.
+  --help | -h               Shows this help and exits.
+EOF
+}
+
+function verify_dependencies() {
+  if false; then
+    finalize 1 "dependency failed"
+  fi
+}
+
+# Some basic includes
+source lib/debug.bash
+source lib/temp.bash
+source lib/utils.bash
+source lib/config.bash
+source version
+
+# Parse the commandline into an array
+commandline_to_array ARR "$@"
+
+n=0
+while [ $n -lt ${#ARR[@]} ]; do
+    PARAM="${ARR[$n]}"
+    case "$PARAM" in
+        --verbose|-v)           VERBOSE=true;;
+        --debug)                DEBUG=true;;
+        --version | -V)         echo "$VERSION" && finalize;;
+        --help | -h)            usage && finalize;;
+        *)                      usage && finalize 1 "invalid parameter $PARAM";;
+    esac
+    n=$(($n+1))
+done
+
+verify_dependencies

--- a/src/bashcgen
+++ b/src/bashcgen
@@ -1,0 +1,108 @@
+#!/bin/bash
+#
+# bashcgen - creates a basic bashc application based on a template
+# https://github.com/
+#
+# Copyright (C) GRyCAP - I3M - UPV 
+# Developed by Carlos A. caralla@upv.es
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+function usage() {
+  cat <<EOF
+
+This tool creates a template for an application
+
+$0 <appname>
+
+  --folder | -f <folder>    Sets the folder in which the template is being created
+                            (default: ./appname)
+  --template | -t <name>    Makes use of the template named <name> (default: bash)
+  --license | -l <license>  Includes the license and license notices named <license> 
+                            (default: apache2)
+  --version | -V            Shows the version number and finalizes.
+  --verbose | -v            Shows more information about the procedure.
+  --debug                   Shows a lot more information about the procedure.
+  --help | -h               Shows this help and exits.
+EOF
+}
+
+function verify_dependencies() {
+  if false; then
+    bashc.finalize 1 "dependency failed"
+  fi
+}
+
+# Some basic includes
+source lib/debug.bash
+source lib/temp.bash
+source lib/utils.bash
+source lib/config.bash
+source version
+
+# Parse the commandline into an array
+bashc.commandline_to_array ARR "$@"
+
+function bashc.hello() {
+  echo "hello world"
+}
+
+function nextparam() {
+  n=$((n+1))
+  PARAM="${ARR[$n]}"
+}
+
+FOLDER=
+APPNAME=
+
+n=0
+while [ $n -lt ${#ARR[@]} ]; do
+    PARAM="${ARR[$n]}"
+    case "$PARAM" in
+        --folder|-f)            nextparam
+                                FOLDER="$PARAM";;
+        --template|-t)          bashc.finalize 1 "template usage not implemented";;
+        --license|-l)           bashc.finalize 1 "license usage not implemented";;
+        --verbose|-v)           VERBOSE=true;;
+        --debug)                DEBUG=true;;
+        --version | -V)         echo "$VERSION" && bashc.finalize;;
+        --help | -h)            usage && bashc.finalize;;
+        *)                      if [ "$APPNAME" == "" ]; then
+                                  APPNAME="$PARAM"
+                                else
+                                  usage && bashc.finalize 1 "invalid parameter $PARAM"
+                                fi;;
+    esac
+    n=$(($n+1))
+done
+
+verify_dependencies
+
+if [ "$APPNAME" == "" ]; then
+  bashc.finalize 1 "no appname set"
+fi
+
+if [[ ! "$APPNAME" =~ ^[A-Za-z0-9]*$ ]]; then
+  bashc.finalize 1 "the name $APPNAME is not a valid name for an application"
+fi
+
+if [ "$FOLDER" == "" ]; then
+  FOLDER="./$APPNAME"
+fi
+
+if [ -d "$FOLDER" ]; then
+  bashc.finalize 1 "folder $FOLDER already exists"
+fi
+
+p_debug "creating app $APPNAME in folder $FOLDER"

--- a/src/legacy/INSTALL.sh
+++ b/src/legacy/INSTALL.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+#
+# bashkeleton - Skeleton for Bash applications
+# https://github.com/dealfonso/bashkeleton
+#
+# Copyright (C) caralla@upv.es
+# Developed by Carlos A. caralla@upv.es
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# USAGE:
+# This script will be called as 
+#
+# ./INSTALL <src folder> <prefix>
+#
+# It will install the application into the folder <prefix>. If you want to
+#   make a system-wide installation, please include / as prefix. The purpose
+#   of using a prefix is mainly to generate packages.
+#
+# CONFIGURATION:
+#
+# Update the following values for the files that implement your package
+
+# Files that will be bashflattened to get a single file without dependencies 
+#   (i.e. will try to remove "source" dependencies of the scripts). These
+#   files will be copied to <PREFIX>/usr/share/$APPNAME folder
+APPBASHFLATTEN=""
+
+# Files that will be copied as-is to <PREFIX>/usr/share/$APPNAME folder
+APPFILES="version LICENSE"
+
+# Files that will be copied as-is to <PREFIX>/usr/bin folder
+APPBINFILES=""
+
+# Files that will be bashflattened to get a single file without dependencies 
+#   (i.e. will try to remove "source" dependencies of the scripts). These
+#   files will be copied to <PREFIX>/usr/bin folder
+APPBASHFLATTENBINFILES="bashkeleton"
+
+# ---------------------------------------------------------------------
+# DO NOT MODIFY from here on
+# ---------------------------------------------------------------------
+
+function _chmod() {
+  local RECURSE="$1"
+  local MODE
+  if [ "$RECURSE" == "-R" ]; then
+    shift
+    MODE="$1"
+  else
+    MODE="$RECURSE"
+    RECURSE=
+  fi
+  shift
+  if [ "$1" != "" ]; then
+    chmod $RECURSE "$MODE" "$@"
+  fi
+}
+
+SRCFOLDER="${1:-.}"
+PREFIX="${2:-/}"
+
+source "${SRCFOLDER}/appname"
+if [ $? -ne 0 -o "$APPNAME" == "" ]; then
+  echo "could not find the name of the application"
+  exit 1
+fi
+
+APPDIR="/usr/share/$APPNAME"
+ETCDIR="/etc/$APPNAME"
+
+mkdir -p "${PREFIX}/usr/bin"
+mkdir -p "${PREFIX}/$APPDIR"
+mkdir -p "${PREFIX}/${ETCDIR}"
+
+for i in $APPFILES; do
+  D="$(dirname $i)"
+  if [ "$D" == ".." -o "$D" == "." ]; then
+    D=
+  fi
+  D="${PREFIX}/$APPDIR/$D"
+  mkdir -p "$D"
+  cp -r "$SRCFOLDER/$i" "$D"
+done
+
+for i in $APPBASHFLATTEN; do
+  F="$(basename "$i")"
+  ${SRCFOLDER}/bashflatten -C "${SRCFOLDER}/$i" > "${PREFIX}/$APPDIR/$F" 
+done
+
+for i in $APPBINFILES; do
+  cp -r "$SRCFOLDER/$i" "${PREFIX}/usr/bin/"
+  _chmod -R 755 "${PREFIX}/usr/bin/$i"
+done
+
+for i in $APPBASHFLATTENBINFILES; do
+  F="$(basename "$i")"
+  ${SRCFOLDER}/bashflatten -C "${SRCFOLDER}/$i" > "${PREFIX}/usr/bin/$F" 
+  _chmod 755 "${PREFIX}/usr/bin/$F"
+done
+
+APPETCFILES="etc/$APPNAME"
+for i in "$APPETCFILES"; do
+  D="$(dirname $i)"
+  if [ "$D" == ".." -o "$D" == "." ]; then
+    D=
+  fi
+  if [ -e "$SRCFOLDER/$i" ]; then
+    D="${PREFIX}/$D"
+    mkdir -p "$D"
+    cp -r "$SRCFOLDER/$i" "$D"
+  fi
+done
+
+if [ "$PREFIX" != "/" ]; then
+  _chmod 755 ${PREFIX}/etc
+fi
+
+_chmod 755 $(find ${PREFIX}/${ETCDIR} -type d)
+_chmod 644 $(find ${PREFIX}/${ETCDIR} ! -type d)
+_chmod 755 ${PREFIX}/$APPDIR
+_chmod 755 $(find ${PREFIX}/$APPDIR/ -type d)
+_chmod 644 $(find ${PREFIX}/$APPDIR/ ! -type d)

--- a/src/legacy/appname
+++ b/src/legacy/appname
@@ -1,0 +1,1 @@
+APPNAME=bashkeleton

--- a/src/lib/config.bash
+++ b/src/lib/config.bash
@@ -1,6 +1,6 @@
 # Reads a configuration file and set its variables (removes comments, blank lines, trailing spaces, etc. and
 # then reads KEY=VALUE settings)
-function bashc.readconf() {
+function bashc.Xreadconf() {
   local _CONF_FILE=$1
   local _CURRENT_SECTION
   local _TXT_CONF
@@ -14,10 +14,10 @@ function bashc.readconf() {
   # First we read the config file
   _TXT_CONF="$(cat "$_CONF_FILE" | sed 's/#.*//g' | sed 's/^[ \t]*//g' | sed 's/[ \t]*$//g' | sed '/^$/d')"
 
-  # Let's read the lines
+  # Lets read the lines
   while read L; do
     if [[ "$L" =~ ^\[.*\]$ ]]; then
-      # If we are reading a section, let's see if it is applicable to us
+      # If we are reading a section, lets see if it is applicable to us
       _CURRENT_SECTION="${L:1:-1}"
     else
       IFS='=' read _CURRENT_KEY _CURRENT_VALUE <<< "$L"
@@ -25,5 +25,90 @@ function bashc.readconf() {
       read -d '\0' "$_CURRENT_KEY" <<< "${_CURRENT_VALUE}"
     fi
   done <<< "$_TXT_CONF"
+  return 0
+}
+
+function bashc.readconf() {
+  local _CONF_FILE=$1
+  local _TXT_CONF
+  local _CURRENT_KEY _CURRENT_VALUE
+  local L
+  local _VALID_KEYS=( )
+
+  # Now read the valid keys
+  shift
+  bashc.list_append _VALID_KEYS "$@"
+
+  # If the config file does not exist return failure
+  if [ ! -e "$_CONF_FILE" ]; then
+    return 255
+  fi
+
+  # First we read the config file
+  _TXT_CONF="$(cat "$_CONF_FILE" | sed 's/^[ \t]*//g' | sed 's/[ \t]*$//g' | sed '/^$/d')"
+
+  local _EXITCODE=0
+  # Let's read the lines
+  while read L; do
+    if [[ "$L" =~ ^[[:blank:]]*[A-Za-z_][A-Za-z0-9_]*= ]]; then
+      IFS='=' read _CURRENT_KEY _CURRENT_VALUE <<< "$L"
+      _CURRENT_VALUE="$(bashc.cleanvalue "$_CURRENT_VALUE")"
+      if [ $? -ne 0 ]; then
+        p_warning "ignoring invalid value for key $_CURRENT_KEY"
+        _EXITCODE=$((_EXITCODE+1))
+      else
+        _CURRENT_VALUE="$(echo "$_CURRENT_VALUE" | envsubst)"
+        if [ ${#_VALID_KEYS[@]} -eq 0 ] || bashc.in_list _VALID_KEYS $_CURRENT_KEY; then
+          p_debug "$_CURRENT_KEY value acquired"
+          read -d '\0' "$_CURRENT_KEY" <<< "${_CURRENT_VALUE}"
+        else
+          p_warning "$_CURRENT_KEY ignored"
+        fi
+        p_debug "$_CURRENT_KEY=$_CURRENT_VALUE"
+      fi
+    else
+      if [ "${L%%\#*}" != "" ]; then
+        p_error "invalid configuration line '$L'"
+        _EXITCODE=$((_EXITCODE+1))
+      fi
+    fi
+    if ((_EXITCODE>=254)); then
+      p_error "too errors to consider this file"
+      return $_EXITCODE
+    fi
+  done <<< "$_TXT_CONF"
+  return $_EXITCODE
+}
+
+function bashc.cleanvalue() {
+  local A="$1"
+  local VALUE=
+  local STILL_WORKING="true"
+  while [ "$STILL_WORKING" == "true" ]; do
+    STILL_WORKING="false"
+    if [[ "$A" =~ ^[^\#\"\'[:space:]]+ ]]; then
+      VALUE="${VALUE}${BASH_REMATCH[0]}"
+      A="${A:${#BASH_REMATCH[0]}}"
+      STILL_WORKING="true"
+    fi
+    if [ "$STILL_WORKING" == "false" ] && [[ "$A" =~ ^\"([^\"\\]*(\\.[^\"\\]*)*)\" ]]; then
+      VALUE="${VALUE}${BASH_REMATCH[1]}"
+      A="${A:${#BASH_REMATCH[0]}}"
+      STILL_WORKING="true"
+    fi
+    if [ "$STILL_WORKING" == "false" ] && [[ "$A" =~ ^\'([^\']*)\' ]]; then
+      VALUE="${VALUE}${BASH_REMATCH[1]}"
+      A="${A:${#BASH_REMATCH[0]}}"
+      STILL_WORKING="true"
+    fi
+  done
+  echo "$VALUE"
+  A="$(bashc.trim "$A")"
+  if [ "${A:0:1}" == "#" ]; then
+    return 0
+  fi
+  if [ "$A" != "" ]; then
+    return 1
+  fi
   return 0
 }

--- a/src/lib/config.bash
+++ b/src/lib/config.bash
@@ -1,0 +1,29 @@
+# Reads a configuration file and set its variables (removes comments, blank lines, trailing spaces, etc. and
+# then reads KEY=VALUE settings)
+function bashc.readconf() {
+  local _CONF_FILE=$1
+  local _CURRENT_SECTION
+  local _TXT_CONF
+  local _CURRENT_KEY _CURRENT_VALUE
+
+  # If the config file does not exist return failure
+  if [ ! -e "$_CONF_FILE" ]; then
+    return 1
+  fi
+
+  # First we read the config file
+  _TXT_CONF="$(cat "$_CONF_FILE" | sed 's/#.*//g' | sed 's/^[ \t]*//g' | sed 's/[ \t]*$//g' | sed '/^$/d')"
+
+  # Let's read the lines
+  while read L; do
+    if [[ "$L" =~ ^\[.*\]$ ]]; then
+      # If we are reading a section, let's see if it is applicable to us
+      _CURRENT_SECTION="${L:1:-1}"
+    else
+      IFS='=' read _CURRENT_KEY _CURRENT_VALUE <<< "$L"
+      _CURRENT_VALUE="$(echo "$_CURRENT_VALUE" | envsubst)"
+      read -d '\0' "$_CURRENT_KEY" <<< "${_CURRENT_VALUE}"
+    fi
+  done <<< "$_TXT_CONF"
+  return 0
+}

--- a/src/lib/debug.bash
+++ b/src/lib/debug.bash
@@ -1,0 +1,92 @@
+_MUTED_EXPRESSIONS=()
+
+function p_mute() {
+  _MUTED_EXPRESSIONS+=("${1// /[[:space:]]}")
+}
+
+function p_errfile() {
+  local i
+  local E
+  for ((i=0;i<${#_MUTED_EXPRESSIONS[@]};i=i+1)); do
+    E="${_MUTED_EXPRESSIONS[$i]}"
+    if [[ "$1" =~ ^$E ]]; then
+      return 0
+    fi
+  done
+
+  if [ "$LOGFILE" == "" ]; then
+    echo "$@" >&2
+  else
+    touch -f "$LOGFILE"
+    if [ $? -eq 0 ]; then
+      echo "$@" >> "$LOGFILE"
+    fi
+  fi
+}
+
+function p_error() {
+  local O_STR="[ERROR] $LOGGER $(date +%Y.%m.%d-%X) $@"
+  p_errfile "$O_STR"
+}
+
+function p_warning() {
+  local O_STR="[WARNING] $LOGGER $(date +%Y.%m.%d-%X) $@"
+  p_errfile "$O_STR"
+}
+
+function p_info() {
+  local L
+  if [ "$VERBOSE" == "true" ]; then
+    local TS="$(date +%Y.%m.%d-%X)"
+    while read L; do
+      p_errfile "[INFO] $LOGGER $TS $@"
+    done <<< "$@"
+  fi
+}
+
+function p_out() {
+  if [ "$QUIET" != "true" ]; then
+    while read L; do
+      echo "$@"
+    done <<< "$@"
+  fi
+}
+
+function p_debug() {
+  local L
+  if [ "$DEBUG" == "true" ]; then
+    local TS="$(date +%Y.%m.%d-%X)"
+    while read L; do
+      p_errfile "[DEBUG] $LOGGER $TS $L"
+    done <<< "$@"
+  fi
+}
+
+function bashc.set_logger() {
+  if [ "$1" != "" ]; then
+    LOGGER="[$1]"
+  else
+    LOGGER=
+  fi
+}
+
+_OLD_LOGGER=
+
+function bashc.push_logger() {
+  _OLD_LOGGER="$LOGGER"
+  LOGGER="$LOGGER[$1]"
+}
+
+function bashc.pop_logger() {
+  LOGGER="$_OLD_LOGGER"
+}
+
+function bashc.finalize() {
+  # Finalizes the execution of the this script and shows an error (if provided)
+  local ERR=$1
+  shift
+  local COMMENT=$@
+  [ "$ERR" == "" ] && ERR=0
+  [ "$COMMENT" != "" ] && p_error "$COMMENT"
+  exit $ERR
+}

--- a/src/lib/debug.bash
+++ b/src/lib/debug.bash
@@ -38,7 +38,7 @@ function p_info() {
   local L
   if [ "$VERBOSE" == "true" ]; then
     local TS="$(date +%Y.%m.%d-%X)"
-    while read L; do
+    while read; do
       p_errfile "[INFO] $LOGGER $TS $@"
     done <<< "$@"
   fi
@@ -46,7 +46,7 @@ function p_info() {
 
 function p_out() {
   if [ "$QUIET" != "true" ]; then
-    while read L; do
+    while read; do
       echo "$@"
     done <<< "$@"
   fi
@@ -56,8 +56,8 @@ function p_debug() {
   local L
   if [ "$DEBUG" == "true" ]; then
     local TS="$(date +%Y.%m.%d-%X)"
-    while read L; do
-      p_errfile "[DEBUG] $LOGGER $TS $L"
+    while read; do
+      p_errfile "[DEBUG] $LOGGER $TS $REPLY"
     done <<< "$@"
   fi
 }

--- a/src/lib/parameters.bash
+++ b/src/lib/parameters.bash
@@ -1,0 +1,44 @@
+
+_BASHC_current_param_id=-1
+_BASHC_COMMANDLINE_ARRAY=( )
+function bashc.parameters_start() {
+  _BASHC_current_param_id=-1
+}
+
+function bashc.parameters_next() {
+  _BASHC_current_param_id=$((_BASHC_current_param_id+1))
+  if ((_BASHC_current_param_id<${#_BASHC_COMMANDLINE_ARRAY[@]})); then
+    return 0
+  fi
+  return 1
+}
+
+function bashc.parameters_end() {
+  if ((_BASHC_current_param_id<${#_BASHC_COMMANDLINE_ARRAY[@]})); then
+    return 1
+  fi
+  return 0
+}
+
+function bashc.parameter_current() {
+  echo "${_BASHC_COMMANDLINE_ARRAY[$_BASHC_current_param_id]}"
+}
+
+function bashc.parameter_parse_commandline() {
+  local n=0
+  local f
+  while [ $# -gt 0 ]; do
+      if [ "${1:0:1}" == "-" -a "${1:1:1}" != "-" -a "${1:1:1}" != "" ]; then
+          for f in $(echo "${1:1}" | sed 's/\(.\)/-\1 /g' ); do
+              _BASHC_COMMANDLINE_ARRAY[$n]="$f"
+              n=$(($n+1))
+          done
+      else
+          _BASHC_COMMANDLINE_ARRAY[$n]="$1"
+          n=$(($n+1))
+      fi
+      shift
+  done
+  return $n
+}
+

--- a/src/lib/parameters.bash
+++ b/src/lib/parameters.bash
@@ -20,7 +20,7 @@ function bashc.parameters_end() {
   return 0
 }
 
-function bashc.parameter_current() {
+function bashc.parameters_current() {
   echo "${_BASHC_COMMANDLINE_ARRAY[$_BASHC_current_param_id]}"
 }
 

--- a/src/lib/temp.bash
+++ b/src/lib/temp.bash
@@ -1,0 +1,34 @@
+function bashc.tempfile {
+  local FOLDER="$1"
+  if [ "$FOLDER" == "" ]; then
+    FOLDER=/tmp
+  fi
+  if [ ! -d "$FOLDER" ]; then
+    finalize 1 "folder $FOLDER does not exist"
+  fi
+  RES=$FOLDER/ftemp_${RANDOM}_$(date +%s)
+  touch $RES
+  while [ $? -ne 0 ]; do
+    RES=$FOLDER/ftemp_${RANDOM}_$(date +%s)
+    touch $RES
+  done
+  echo $RES
+}
+
+function bashc.tempdir() {
+  # Creates a unique temporary folder
+  local FOLDER="$1"
+  if [ "$FOLDER" == "" ]; then
+    FOLDER=/tmp
+  fi
+  if [ ! -d "$FOLDER" ]; then
+    finalize 1 "folder $FOLDER does not exist"
+  fi
+  RES=$FOLDER/ftemp_${RANDOM}_$(date +%s)
+  mkdir -p $RES 2> /dev/null
+  while [ $? -ne 0 ]; do
+    RES=$FOLDER/ftemp_${RANDOM}_$(date +%s)
+    mkdir -p $RES 2> /dev/null
+  done
+  echo $RES
+}

--- a/src/lib/utils.bash
+++ b/src/lib/utils.bash
@@ -6,6 +6,20 @@ function bashc.trim() {
   echo "$A"
 }
 
+function bashc.ltrim() {
+  shopt -s extglob
+  local A="${1##+([[:space:]])}"
+  shopt -u extglob
+  echo "$A"
+}
+
+function bash.rtrim() {
+  shopt -s extglob
+  local A="${1%%+([[:space:]])}"
+  shopt -u extglob
+  echo "$A"
+}
+
 function bashc.build_cmdline() {
   local SHCMDLINE=""
   while [ $# -gt 0 ]; do
@@ -17,6 +31,76 @@ function bashc.build_cmdline() {
     shift
   done
   echo "$SHCMDLINE"
+}
+
+function bashc.dump_list() {
+  # Usage:
+  # bashc.dump_list "${ARRNAME[@]}"
+  local n=0
+  while [ $# -gt 0 ]; do
+    p_debug "$n: $1"
+    shift
+    n=$((n+1))
+  done
+}
+
+function bashc.parameters_to_list() {
+  # Usage:
+  #  bashc.parameters_to_list ARRNAME p1 p2 p3 p4
+  # Effect:
+  #  ARRNAME
+  local AN="$1"
+  local n=0
+  shift
+  eval "$AN=( )"
+  while [ $# -gt 0 ]; do
+    read ${AN}[$n] <<< "$1"
+    n=$((n+1))
+    shift
+  done
+}
+
+function bashc.list_append() {
+  # Usage:
+  #  bashc.parameters_to_list ARRNAME p1 p2 p3 p4
+  # Effect:
+  #  ARRNAME
+  local AN="$1"
+  local SIZE=$(eval "echo \${#$AN[@]}")
+  local n
+  shift
+  if bashc.is_int "$SIZE"; then
+    n=$SIZE
+    while [ $# -gt 0 ]; do
+      read ${AN}[$n] <<< "$1"
+      n=$((n+1))
+      shift
+    done
+  fi
+}
+
+function bashc.in_list() {
+  # Usage:
+  #  bashc.in_list ARRNAME <elem>
+  local AN="$1"
+  local SIZE=$(eval "echo \${#$AN[@]}")
+  local T n
+  if bashc.is_int "$SIZE"; then
+    for ((n=0;n<SIZE;n=n+1)); do 
+      T="$AN[$n]"
+      if [ "${!T}" == "$2" ]; then
+        return 0
+      fi
+    done
+  fi
+  return 1
+}
+
+function bashc.is_int() {
+  if [[ "$1" =~ ^[+-]{0,1}[0-9]+$ ]]; then
+    return 0
+  fi
+  return 1
 }
 
 function bashc.arrayze_cmd() {

--- a/src/lib/utils.bash
+++ b/src/lib/utils.bash
@@ -1,0 +1,50 @@
+function bashc.trim() {
+  shopt -s extglob
+  local A="${1##+([[:space:]])}"
+  A="${A%%+([[:space:]])}"
+  shopt -u extglob
+  echo "$A"
+}
+
+function bashc.build_cmdline() {
+  local SHCMDLINE=""
+  while [ $# -gt 0 ]; do
+    if [ "$1" == "|" -o "$1" == "&&" -o "$1" == ">" -o "$1" == ">>" -o "$1" == "2>" -o "$1" == "2>>" -o "$1" == "<" -o "$1" == "<<" ]; then
+      SHCMDLINE="${SHCMDLINE} $1"
+    else
+      SHCMDLINE="${SHCMDLINE} \"$1\""
+    fi
+    shift
+  done
+  echo "$SHCMDLINE"
+}
+
+function bashc.arrayze_cmd() {
+  # This function creates an array of parameters from a commandline. The special
+  # function of this function is that sometimes parameters are between quotes and the
+  # common space-separation is not valid. This funcion solves the problem of quotes and
+  # then a commandline can be invoked as "${ARRAY[@]}"
+  local AN="$1"
+  local _CMD="$2"
+  local R n=0
+  while read R; do
+    read ${AN}[$n] <<< "$R"
+    n=$((n+1))
+  done < <(printf "%s\n" "$_CMD" | xargs -n 1 printf "%s\n")
+}
+
+function bashc.lines_to_array() {
+  local AN="$1"
+  local LINES="$2"
+  local L
+  local n=0
+  while read L; do
+    read ${AN}[$n] <<< "$L"
+    n=$((n+1))
+  done <<< "$LINES"
+}
+
+function bashc.sanitize() {
+  echo "$1" | sed -e 's/\([[\/.*]\|\]\)/\\&/g'
+}
+

--- a/src/version
+++ b/src/version
@@ -1,0 +1,1 @@
+VERSION=0.0-beta.0


### PR DESCRIPTION
First working version of **bashc**, that comes from the original **bashflatten**.

This version makes use of the BASHC_LIB_PATH to search for the included files and strips the unused functions of the final code.

**Note:** the current version is not currently installable.